### PR TITLE
feat: support $control.focus() properly

### DIFF
--- a/wdio-ui5-service/src/lib/WDI5.js
+++ b/wdio-ui5-service/src/lib/WDI5.js
@@ -163,7 +163,14 @@ module.exports = class WDI5 {
                         result = window.wdi5.createControlIdMap(result);
                         done(['success', result, 'aggregation']);
                     } else {
-                        if (result === undefined || result === null) {
+                        // ui5 api <control>.focus() doesn't have return value
+                        if (methodName === 'focus' && result === undefined) {
+                            done([
+                                'success',
+                                `called focus() on wdi5 representation of a ${metadata.getElementName()}`,
+                                'element'
+                            ]);
+                        } else if (result === undefined || result === null) {
                             done([
                                 'error',
                                 `function ${methodName} does not exist on control ${metadata.getElementName()}!`,

--- a/wdio-ui5-service/test/ui5.test.js
+++ b/wdio-ui5-service/test/ui5.test.js
@@ -71,6 +71,16 @@ describe('basics', () => {
 
         expect(browser.asControl(selectorWithoutId).getText()).toBe('Get Started with UI5');
     });
+
+    it('should not report an error on successful $control.focus()', () => {
+        const focusResult = browser.asControl(selectorVersionButton).focus();
+        expect(focusResult).toBeTruthy();
+    });
+    it('should throw an error on unsuccessful $control.focus()', () => {
+        expect(() => {
+            browser.asControl({selector: {id: 'doesnt_exist'}}).focus();
+        }).toThrow();
+    });
 });
 
 describe('locate ui5 control via regex', () => {

--- a/wdio-ui5-service/test/ui5.test.js
+++ b/wdio-ui5-service/test/ui5.test.js
@@ -75,6 +75,10 @@ describe('basics', () => {
     it('should not report an error on successful $control.focus()', () => {
         const focusResult = browser.asControl(selectorVersionButton).focus();
         expect(focusResult).toBeTruthy();
+
+        // assert focus on element also via webdriver.io api
+        const wdFocusResult = focusResult.getWebElement();
+        expect(wdFocusResult.isFocused()).toBeTruthy();
     });
     it('should throw an error on unsuccessful $control.focus()', () => {
         expect(() => {


### PR DESCRIPTION
so far, focus() on a selected <control> worked
but delivered the wrong return value,
incorrectly reporting an error