### PR TITLE
feat: fluent async api

### DIFF
--- a/.github/workflows/wdi5-tests.js.yml
+++ b/.github/workflows/wdi5-tests.js.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [14, 16, 17]
 
     steps:
       - name: update chrome

--- a/.github/workflows/wdio-ui5-service-tests.js.yml
+++ b/.github/workflows/wdio-ui5-service-tests.js.yml
@@ -38,5 +38,8 @@ jobs:
       - name: install packages
         run: yarn install --ignore-engines --frozen-lockfile
 
-      - name: run webdriver.io-plugin tests
-        run: HEADLESS=true yarn test:ci:wdio-ui5-service
+      - name: run wdi5 as webdriver.io-plugin tests
+        run: HEADLESS=true yarn test:ui5
+
+      - name: run late injecting wdi5 as webdriver.io-plugin tests
+        run: HEADLESS=true yarn test:ui5-late

--- a/.github/workflows/wdio-ui5-service-tests.js.yml
+++ b/.github/workflows/wdio-ui5-service-tests.js.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14]
+        node-version: [14, 16, 17]
 
     steps:
       - name: update chrome

--- a/.github/workflows/wdio-ui5-service-tests.js.yml
+++ b/.github/workflows/wdio-ui5-service-tests.js.yml
@@ -42,4 +42,4 @@ jobs:
         run: HEADLESS=true yarn test:ui5
 
       - name: run late injecting wdi5 as webdriver.io-plugin tests
-        run: HEADLESS=true yarn test:ui5-late
+        run: HEADLESS=true yarn test:ui5_late

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/fermium
+lts/gallium

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "//test:withUI5tooling": "this only runs basic.test.js, but served by the ui5 tooling",
     "test:withUI5tooling": "run-p -r _startApp:withUI5tooling _test:withUI5tooling",
     "test:dist": "npm-run-all -r _build:ui5_app --parallel _startApp:dist _test",
-    "test:ci:wdio-ui5-service": "HEADLESS=true run-s test:ui5 test:ui5_late",
+    "//(not used anymore)test:ci:wdio-ui5-service": "HEADLESS=true run-s test:ui5 test:ui5_late",
     "test:ci:wdi5": "HEADLESS=true npm run test",
     "test:ci:wdi5:withUI5tooling": "HEADLESS=true npm run test:withUI5tooling",
     "test:ci:wdi5:dist": "HEADLESS=true npm run test:dist",

--- a/test/ui5-app/webapp/test/e2e/fluent-async-api.test.js
+++ b/test/ui5-app/webapp/test/e2e/fluent-async-api.test.js
@@ -35,4 +35,18 @@ describe('async api', () => {
         const title = await browser.asControl(listSelector).getItems(1).getTitle();
         expect(title).toBe('Andrew Fuller');
     });
+
+    it('chain events, setter and getter', async () => {
+        const selector = {
+            selector: {
+                id: 'idAddLineItemButton',
+                viewName: 'test.Sample.view.Other'
+            }
+        };
+        const oldText = await browser.asControl(selector).firePress().getText();
+        expect(oldText).toBe('add Line Item');
+        const _newText = 'changed!';
+        const newText = await browser.asControl(selector).firePress().setText(_newText).getText();
+        expect(newText).toBe(_newText);
+    });
 });

--- a/test/ui5-app/webapp/test/e2e/fluent-async-api.test.js
+++ b/test/ui5-app/webapp/test/e2e/fluent-async-api.test.js
@@ -1,0 +1,38 @@
+const wdi5 = require('wdi5');
+const Other = require('./pageObjects/Other');
+
+const listSelector = {
+    forceSelect: true,
+    selector: {
+        id: 'PeopleList',
+        viewName: 'test.Sample.view.Other'
+    }
+};
+
+const tests = [{api: 'asControl'}, {api: '_asControl'}];
+
+describe('async api', () => {
+    before(async () => {
+        await Other.open();
+    });
+
+    for (const test of tests) {
+        it(`api: browser.${test.api} - getItems(x) and getTitle() in sequence`, async () => {
+            const list = await browser[test.api](listSelector);
+            (await wdi5()).getLogger().info('//> ********************');
+            (await wdi5()).getLogger().info('//> done with sap.m.List');
+            const listItem = await list.getItems(1); // ui5 api
+            (await wdi5()).getLogger().info('//> ********************');
+            (await wdi5()).getLogger().info('//> done with List Item');
+            const title = await listItem.getTitle(); // ui5 api
+            (await wdi5()).getLogger().info('//> ********************');
+            (await wdi5()).getLogger().info('//> done with sap.m.Title');
+            expect(title).toBe('Andrew Fuller');
+        });
+    }
+
+    it('chain getItems(x) and getTitle()', async () => {
+        const title = await browser.asControl(listSelector).getItems(1).getTitle();
+        expect(title).toBe('Andrew Fuller');
+    });
+});

--- a/test/ui5-app/webapp/test/e2e/fluent-async-api.test.js
+++ b/test/ui5-app/webapp/test/e2e/fluent-async-api.test.js
@@ -2,7 +2,7 @@ const wdi5 = require('wdi5');
 const Other = require('./pageObjects/Other');
 
 const listSelector = {
-    forceSelect: true,
+    // forceSelect: true,
     selector: {
         id: 'PeopleList',
         viewName: 'test.Sample.view.Other'

--- a/wdio-ui5-service/src/lib/wdioUi5-index.js
+++ b/wdio-ui5-service/src/lib/wdioUi5-index.js
@@ -519,13 +519,13 @@ function setup(context) {
         }
     });
 
-    // inspired by and after starting a long time hard at:
+    // inspired by and after staring a long time hard at:
     // https://stackoverflow.com/questions/51635378/keep-object-chainable-using-async-methods
     // https://github.com/Shigma/prochain
     // https://github.com/l8js/l8/blob/main/src/core/liquify.js
 
     // channel the async function browser._asControl (init'ed via _context.addCommand above) through a Proxy
-    // in order to chain calls of any subsequent UI5 api calls on the retrieved UI5 control:
+    // in order to chain calls of any subsequent UI5 api methods on the retrieved UI5 control:
     // await browser.asControl(selector).methodOfUI5control().anotherMethodOfUI5control()
     // the way this works is twofold:
     // 1. (almost) all UI5 $control's API methods are reinjected from the browser-scope

--- a/wdio-ui5-service/src/lib/wdioUi5-index.js
+++ b/wdio-ui5-service/src/lib/wdioUi5-index.js
@@ -534,8 +534,8 @@ function setup(context) {
     // 2. the execution of each UI5 $control's API method (via async WDI5._executeControlMethod() => Promise) is then chained
     //    via the below "then"-ing of the (async WDI5._executeControlMethod() => Promise)-Promises with the help of
     //    the a Proxy and a recursive `handler` function
-    if (context && !context.asControl) {
-        context.asControl = function (ui5ControlSelector) {
+    if (_context && !_context.asControl) {
+        _context.asControl = function (ui5ControlSelector) {
             const asyncMethods = ['then', 'catch', 'finally'];
             function makeFluent(target) {
                 const promise = Promise.resolve(target);
@@ -553,7 +553,7 @@ function setup(context) {
                 };
                 return new Proxy(function () {}, handler);
             }
-            return makeFluent(context._asControl(ui5ControlSelector));
+            return makeFluent(_context._asControl(ui5ControlSelector));
         };
     }
 

--- a/wdio-ui5-service/src/lib/wdioUi5-index.js
+++ b/wdio-ui5-service/src/lib/wdioUi5-index.js
@@ -519,24 +519,41 @@ function setup(context) {
         }
     });
 
+    // inspired by and after starting a long time hard at:
+    // https://stackoverflow.com/questions/51635378/keep-object-chainable-using-async-methods
+    // https://github.com/Shigma/prochain
+    // https://github.com/l8js/l8/blob/main/src/core/liquify.js
+
+    // channel the async function browser._asControl (init'ed via _context.addCommand above) through a Proxy
+    // in order to chain calls of any subsequent UI5 api calls on the retrieved UI5 control:
+    // await browser.asControl(selector).methodOfUI5control().anotherMethodOfUI5control()
+    // the way this works is twofold:
+    // 1. (almost) all UI5 $control's API methods are reinjected from the browser-scope
+    //    into the Node.js scope via async WDI5._executeControlMethod(), which in term actually calls
+    //    the reinjected API method within the browser scope
+    // 2. the execution of each UI5 $control's API method (via async WDI5._executeControlMethod() => Promise) is then chained
+    //    via the below "then"-ing of the (async WDI5._executeControlMethod() => Promise)-Promises with the help of
+    //    the a Proxy and a recursive `handler` function
     if (context && !context.asControl) {
-        context.asControl = function (target) {
+        context.asControl = function (ui5ControlSelector) {
             const asyncMethods = ['then', 'catch', 'finally'];
-            function wrap(target) {
+            function makeFluent(target) {
                 const promise = Promise.resolve(target);
-                const handler2 = {
+                const handler = {
                     get(_, prop) {
                         return asyncMethods.includes(prop)
-                            ? (...args) => wrap(promise[prop](...args))
-                            : wrap(promise.then((target) => target[prop]));
+                            ? (...boundArgs) => makeFluent(promise[prop](...boundArgs))
+                            : makeFluent(promise.then((object) => object[prop]));
                     },
-                    apply(_, thisArg, args) {
-                        return wrap(promise.then((target) => Reflect.apply(target, thisArg, args)));
+                    apply(_, thisArg, boundArgs) {
+                        return makeFluent(
+                            promise.then((targetFunction) => Reflect.apply(targetFunction, thisArg, boundArgs))
+                        );
                     }
                 };
-                return new Proxy(function () {}, handler2);
+                return new Proxy(function () {}, handler);
             }
-            return wrap(context._asControl(target));
+            return makeFluent(context._asControl(ui5ControlSelector));
         };
     }
 

--- a/wdio-ui5-service/test/_selectorList.js
+++ b/wdio-ui5-service/test/_selectorList.js
@@ -1,0 +1,32 @@
+const selectorList = {
+    forceSelect: true,
+    selector: {
+        id: 'versionList',
+        controlType: 'sap.m.Tree',
+        interaction: 'root'
+    }
+};
+exports.selectorList = selectorList;
+const selectorDownloadButton = {
+    selector: {
+        id: 'readMoreButton',
+        controlType: 'sap.m.Button',
+        viewName: 'sap.ui.documentation.sdk.view.Welcome'
+    }
+};
+exports.selectorDownloadButton = selectorDownloadButton;
+const selectorVersionButton = {
+    selector: {
+        id: 'changeVersionButton',
+        controlType: 'sap.m.Button',
+        viewName: 'sap.ui.documentation.sdk.view.App'
+    }
+};
+exports.selectorVersionButton = selectorVersionButton;
+const selectorCookieAccept = {
+    selector: {
+        id: '__button6',
+        controlType: 'sap.m.Button'
+    }
+};
+exports.selectorCookieAccept = selectorCookieAccept;

--- a/wdio-ui5-service/test/regex.test.js
+++ b/wdio-ui5-service/test/regex.test.js
@@ -1,0 +1,69 @@
+const {selectorList, selectorCookieAccept} = require('./_selectorList');
+
+describe('locate ui5 control via regex', () => {
+    before(async () => {
+        if ((await browser.getUI5VersionAsFloat()) <= 1.6) {
+            selectorCookieAccept.forceSelect = true;
+            selectorCookieAccept.selector.interaction = 'root';
+            selectorList.forceSelect = true;
+            selectorList.selector.interaction = 'root';
+        }
+
+        if ((await browser.getUI5VersionAsFloat()) > 1.6) {
+            const buttonCookieAccept = await browser.asControl(selectorCookieAccept);
+            await buttonCookieAccept.firePress();
+        }
+    });
+
+    /**
+     * click the version list button to open a popup on the sdk site
+     * then close it via "esc" key
+     * @param {String|RegExp} idRegex
+     */
+    async function _assert(idRegex) {
+        const selector = {
+            forceSelect: true, // make sure we're retrieving from scratch
+            selector: {
+                id: idRegex
+            }
+        };
+
+        if ((await browser.getUI5VersionAsFloat()) <= 1.6) {
+            selector.forceSelect = true;
+            selector.selector.interaction = 'root';
+        }
+
+        const button = await browser.asControl(selector);
+        await button.firePress();
+        const list = await browser.asControl(selectorList);
+        await expect(await list.getVisible()).toBeTruthy();
+
+        await browser.keys('Escape'); // close popup
+    }
+    it('plain regex /.../', async () => {
+        return await _assert(/.*changeVersionButton$/);
+    });
+
+    it('plain regex + flags /.../gmi', async () => {
+        return await _assert(/.*changeVersionButton$/gim);
+    });
+    it('new RegEx(/.../flags)', async () => {
+        return await _assert(new RegExp(/.*changeVersionButton$/));
+    });
+
+    it('new RegEx(/.../flags)', async () => {
+        return await _assert(new RegExp(/.*changeVersionButton$/gi));
+    });
+
+    it('new RegEx("string")', async () => {
+        return await _assert(new RegExp('.*changeVersionButton$'));
+    });
+
+    it('new RegEx("string", "flags")', async () => {
+        return await _assert(new RegExp('.*changeVersionButton$', 'gmi'));
+    });
+
+    it('regex shorthand matchers are handled properly', async () => {
+        return await _assert(/.*change\w.*Button$/);
+    });
+});

--- a/wdio-ui5-service/test/screenshot.test.js
+++ b/wdio-ui5-service/test/screenshot.test.js
@@ -1,0 +1,42 @@
+const fs = require('fs');
+const path = require('path');
+const {selectorList, selectorCookieAccept} = require('./_selectorList');
+
+describe('screenshots (async tests)', () => {
+    before(async () => {
+        if ((await browser.getUI5VersionAsFloat()) <= 1.6) {
+            selectorCookieAccept.forceSelect = true;
+            selectorCookieAccept.selector.interaction = 'root';
+            selectorList.forceSelect = true;
+            selectorList.selector.interaction = 'root';
+        }
+
+        if ((await browser.getUI5VersionAsFloat()) > 1.6) {
+            const buttonCookieAccept = await browser.asControl(selectorCookieAccept);
+            await buttonCookieAccept.firePress();
+        }
+    });
+    it('should validate screenshots capability', async () => {
+        await browser.screenshot('ui5-sdk-page');
+
+        // seed to wait some time until the screenshot is actually saved to the file system before reading it again
+        setTimeout(() => {
+            const screenShotPath = path.join('wdio-ui5-service', 'test', 'report', 'screenshots');
+            const screenshots = fs.readdirSync(screenShotPath);
+            const ours = screenshots.find((shot) => shot.match(/.*ui5-sdk-page.*/));
+            expect(ours).toMatch(/.*ui5-sdk-page.*/);
+        }, 1500);
+    });
+
+    it('should validate screenshots capability with unnamed screenshot', async () => {
+        await browser.screenshot();
+
+        // seed to wait some time until the screenshot is actually saved to the file system before reading it again
+        setTimeout(() => {
+            const screenShotPath = path.join('wdio-ui5-service', 'test', 'report', 'screenshots');
+            const screenshots = fs.readdirSync(screenShotPath);
+            const ours = screenshots.find((shot) => shot.match(/.*-browser-screenshot.png/));
+            expect(ours).toMatch(/.*-browser-screenshot.png/);
+        }, 1500);
+    });
+});

--- a/wdio-ui5-service/test/ui5-async.test.js
+++ b/wdio-ui5-service/test/ui5-async.test.js
@@ -1,55 +1,20 @@
-const fs = require('fs');
-const path = require('path');
+const {selectorList, selectorDownloadButton, selectorVersionButton, selectorCookieAccept} = require('./_selectorList');
 
-const selectorList = {
-    forceSelect: true,
-    selector: {
-        id: 'versionList',
-        controlType: 'sap.m.Tree',
-        interaction: 'root'
-    }
-};
-
-const selectorDownloadButton = {
-    selector: {
-        id: 'readMoreButton',
-        controlType: 'sap.m.Button',
-        viewName: 'sap.ui.documentation.sdk.view.Welcome'
-    }
-};
-
-const selectorVersionButton = {
-    selector: {
-        id: 'changeVersionButton',
-        controlType: 'sap.m.Button',
-        viewName: 'sap.ui.documentation.sdk.view.App'
-    }
-};
-
-before(async () => {
-    const selectorCookieAccept = {
-        selector: {
-            id: '__button6',
-            controlType: 'sap.m.Button'
-        }
-    };
-
-    if ((await browser.getUI5VersionAsFloat()) <= 1.6) {
-        selectorCookieAccept.forceSelect = true;
-        selectorCookieAccept.selector.interaction = 'root';
-        selectorList.forceSelect = true;
-        selectorList.selector.interaction = 'root';
-    }
-
-    if ((await browser.getUI5VersionAsFloat()) > 1.6) {
-        const buttonCookieAccept = await browser.asControl(selectorCookieAccept);
-        await buttonCookieAccept.firePress();
-    }
-});
+before(async () => {});
 
 describe('basics (async tests)', () => {
     before(async () => {
+        if ((await browser.getUI5VersionAsFloat()) > 1.6) {
+            const buttonCookieAccept = await browser.asControl(selectorCookieAccept);
+            await buttonCookieAccept.firePress();
+        }
+
         if ((await browser.getUI5VersionAsFloat()) <= 1.6) {
+            selectorCookieAccept.forceSelect = true;
+            selectorCookieAccept.selector.interaction = 'root';
+            selectorList.forceSelect = true;
+            selectorList.selector.interaction = 'root';
+
             selectorDownloadButton.forceSelect = true;
             selectorDownloadButton.selector.interaction = 'root';
 
@@ -192,85 +157,5 @@ describe('basics (async tests)', () => {
         }
 
         await expect(await eventsHeader.getVisible()).toBeTruthy();
-    });
-});
-
-describe('screenshots (async tests)', () => {
-    it('should validate screenshots capability', async () => {
-        await browser.screenshot('ui5-sdk-page');
-
-        // seed to wait some time until the screenshot is actually saved to the file system before reading it again
-        setTimeout(() => {
-            const screenShotPath = path.join('wdio-ui5-service', 'test', 'report', 'screenshots');
-            const screenshots = fs.readdirSync(screenShotPath);
-            const ours = screenshots.find((shot) => shot.match(/.*ui5-sdk-page.*/));
-            expect(ours).toMatch(/.*ui5-sdk-page.*/);
-        }, 1500);
-    });
-
-    it('should validate screenshots capability with unnamed screenshot', async () => {
-        await browser.screenshot();
-
-        // seed to wait some time until the screenshot is actually saved to the file system before reading it again
-        setTimeout(() => {
-            const screenShotPath = path.join('wdio-ui5-service', 'test', 'report', 'screenshots');
-            const screenshots = fs.readdirSync(screenShotPath);
-            const ours = screenshots.find((shot) => shot.match(/.*-browser-screenshot.png/));
-            expect(ours).toMatch(/.*-browser-screenshot.png/);
-        }, 1500);
-    });
-});
-
-describe('locate ui5 control via regex', () => {
-    /**
-     * click the version list button to open a popup on the sdk site
-     * then close it via "esc" key
-     * @param {String|RegExp} idRegex
-     */
-    async function _assert(idRegex) {
-        const selector = {
-            forceSelect: true, // make sure we're retrieving from scratch
-            selector: {
-                id: idRegex
-            }
-        };
-
-        if ((await browser.getUI5VersionAsFloat()) <= 1.6) {
-            selector.forceSelect = true;
-            selector.selector.interaction = 'root';
-        }
-
-        const button = await browser.asControl(selector);
-        await button.firePress();
-        const list = await browser.asControl(selectorList);
-        await expect(await list.getVisible()).toBeTruthy();
-
-        await browser.keys('Escape'); // close popup
-    }
-    it('plain regex /.../', async () => {
-        return await _assert(/.*changeVersionButton$/);
-    });
-
-    it('plain regex + flags /.../gmi', async () => {
-        return await _assert(/.*changeVersionButton$/gim);
-    });
-    it('new RegEx(/.../flags)', async () => {
-        return await _assert(new RegExp(/.*changeVersionButton$/));
-    });
-
-    it('new RegEx(/.../flags)', async () => {
-        return await _assert(new RegExp(/.*changeVersionButton$/gi));
-    });
-
-    it('new RegEx("string")', async () => {
-        return await _assert(new RegExp('.*changeVersionButton$'));
-    });
-
-    it('new RegEx("string", "flags")', async () => {
-        return await _assert(new RegExp('.*changeVersionButton$', 'gmi'));
-    });
-
-    it('regex shorthand matchers are handled properly', async () => {
-        return await _assert(/.*change\w.*Button$/);
     });
 });

--- a/wdio-ui5-service/test/wdio-ui5-async.conf.js
+++ b/wdio-ui5-service/test/wdio-ui5-async.conf.js
@@ -44,7 +44,7 @@ exports.config = {
     // will be called from there.
     //
 
-    specs: [path.join('wdio-ui5-service', 'test', 'ui5-async.test.js')],
+    specs: [path.join('wdio-ui5-service', 'test', '*.test.js')],
 
     // Patterns to exclude.
     exclude: [path.join('wdio-ui5-service', 'test', 'ui5-late.test.js')],


### PR DESCRIPTION
this PR enables to `await` a method chain on a retrieved UI5 control:
```js
const title = await browser.asControl(listSelector).getItems(1).getTitle()
expect(title).toBe('Andrew Fuller')
```
this should not only reduce refactoring efforts on existing, `sync`-style notation tests, but also leads to more concise code.
without the fluent async api, the above example would have been:
```js
const list = await browser.asControl(listSelector)
const item = await list.getItems(1)
const title = await item.getTitle()
expect(title).toBe('Andrew Fuller')
```

additionally, tests in `wdio-ui5-service/test` got restructured so they can run in parallel, cutting down test-/ci-time.