### PR TITLE
Feat/164 introduce 1.60 as min UI5 Version

### DIFF
--- a/client-side-js/injectUI5.js
+++ b/client-side-js/injectUI5.js
@@ -58,11 +58,9 @@ async function clientSide_injectUI5(config, waitForUI5Timeout) {
                      * used to dynamically create new control matchers when searching for elements
                      */
                     window.wdi5.createMatcher = (oSelector) => {
-                        // Before version 1.60, the only available criteria is binding context path.
-                        // As of version 1.72, it is available as a declarative matcher
-                        const oldAPIVersion = 1.6
                         // check whether we're looking for a control via regex
                         // hint: no IE support here :)
+                        const oldAPIVersion = "1.72.0"
                         if (oSelector.id && oSelector.id.startsWith("/", 0)) {
                             const [sTarget, sRegEx, sFlags] = oSelector.id.match(/\/(.*)\/(.*)/)
                             oSelector.id = new RegExp(sRegEx, sFlags)
@@ -103,25 +101,30 @@ async function clientSide_injectUI5(config, waitForUI5Timeout) {
                                 // for UI5 < 1.81
                                 oSelector.bindingPath.propertyPath = `/${oSelector.bindingPath.propertyPath}`
                             }
-                            if (oldAPIVersion > parseFloat(sap.ui.version)) {
-                                // for version < 1.60 create the matcher
-                                oSelector.bindingPath = new BindingPath(oSelector.bindingPath)
-                            }
                         }
-
-                        if (oldAPIVersion > parseFloat(sap.ui.version)) {
-                            // for version < 1.60 create the matcher
+                        debugger
+                        if (window.compareVersions.compare(oldAPIVersion, sap.ui.version, ">")) {
+                            oSelector.matchers = []
+                            // for version < 1.72 declarative matchers are not available
+                            if (oSelector.bindingPath) {
+                                oSelector.matchers.push(new BindingPath(oSelector.bindingPath))
+                                delete oSelector.bindingPath
+                            }
                             if (oSelector.properties) {
-                                oSelector.properties = new Properties(oSelector.properties)
+                                oSelector.matchers.push(new Properties(oSelector.properties))
+                                delete oSelector.properties
                             }
                             if (oSelector.i18NText) {
-                                oSelector.i18NText = new I18NText(oSelector.i18NText)
+                                oSelector.matchers.push(new I18NText(oSelector.i18NText))
+                                delete oSelector.i18NText
                             }
                             if (oSelector.labelFor) {
-                                oSelector.labelFor = new LabelFor(oSelector.labelFor)
+                                oSelector.matchers.push(new LabelFor(oSelector.labelFor))
+                                delete oSelector.labelFor
                             }
                             if (oSelector.ancestor) {
-                                oSelector.ancestor = new Ancestor(oSelector.ancestor)
+                                oSelector.matchers.push(new Ancestor(oSelector.ancestor))
+                                delete oSelector.ancestor
                             }
                         }
 

--- a/client-side-js/injectUI5.js
+++ b/client-side-js/injectUI5.js
@@ -104,7 +104,6 @@ async function clientSide_injectUI5(config, waitForUI5Timeout) {
                                 oSelector.bindingPath.propertyPath = `/${oSelector.bindingPath.propertyPath}`
                             }
                         }
-                        debugger
                         if (window.compareVersions.compare(oldAPIVersion, sap.ui.version, ">")) {
                             oSelector.matchers = []
                             // for version < 1.72 declarative matchers are not available

--- a/client-side-js/injectUI5.js
+++ b/client-side-js/injectUI5.js
@@ -58,9 +58,11 @@ async function clientSide_injectUI5(config, waitForUI5Timeout) {
                      * used to dynamically create new control matchers when searching for elements
                      */
                     window.wdi5.createMatcher = (oSelector) => {
+                        // since 1.72.0 the declarative matchers are available. Before that
+                        // you had to instantiate the matchers manually
+                        const oldAPIVersion = "1.72.0"
                         // check whether we're looking for a control via regex
                         // hint: no IE support here :)
-                        const oldAPIVersion = "1.72.0"
                         if (oSelector.id && oSelector.id.startsWith("/", 0)) {
                             const [sTarget, sRegEx, sFlags] = oSelector.id.match(/\/(.*)\/(.*)/)
                             oSelector.id = new RegExp(sRegEx, sFlags)

--- a/examples/ui5-js-app/package.json
+++ b/examples/ui5-js-app/package.json
@@ -11,7 +11,8 @@
     "test": "run-s test:*",
     "test:lateInject": "wdio run wdio-ui5-late.conf.js",
     "test:ui5tooling": "wdio run wdio-ui5tooling.conf.js",
-    "test:webserver": "wdio run wdio-webserver.conf.js"
+    "test:webserver": "wdio run wdio-webserver.conf.js",
+    "test:multiversion": "node wdi5-multiversion.js"
   },
   "devDependencies": {
     "@ui5/cli": "^2.14.6",

--- a/examples/ui5-js-app/wdi5-multiversion.js
+++ b/examples/ui5-js-app/wdi5-multiversion.js
@@ -1,34 +1,35 @@
 const fsExtra = require("fs-extra")
+const path = require("path")
 const replace = require("replace-in-file")
 const Launcher = require("@wdio/cli").default
 
 // lts version - with 1.71.19 being the exception
 // in that there seems to be stuff boken in ui5 > 1.71.19 <= 1.71.25
-const versions = ["1.60.33", "1.71.19", "1.84.3"]
+const versions = ["1.58.4", "1.71.19", "1.84.3"]
 
 ;(async () => {
     for (const version of versions) {
         // create an index.html for bootstrapping per version
-        const targetIndex = `examples/ui5-js-app/webapp/index-${version}.html`
+        const targetIndex = path.resolve(__dirname, `webapp/index-${version}.html`)
         const bootstrapSrc = `https://openui5.hana.ondemand.com/${version}/resources/sap-ui-core.js`
-        fsExtra.copySync("examples/ui5-js-app/webapp/index.html", targetIndex)
+        fsExtra.copySync(path.resolve(__dirname, `webapp/index.html`), targetIndex)
         const optionsIndex = {
             files: targetIndex,
-            from: /src=\".*\"/,
-            to: `src="${bootstrapSrc}"`
+            from: [/src=\".*\"/, /"sap_horizon"/],
+            to: [`src="${bootstrapSrc}"`, "sap_belize"]
         }
         await replace(optionsIndex)
         console.log(`created index-${version}!`)
 
         // create a wdio/wdi5 config per version
-        const targetWdioConf = `examples/ui5-js-app//wdio-wdi5-ui5-${version}.conf.js`
-        fsExtra.copySync("examples/ui5-js-app/wdio-webserver.conf.js", targetWdioConf)
+        const targetWdioConf = path.resolve(__dirname, `wdio-wdi5-ui5-${version}.conf.js`)
+        fsExtra.copySync(path.resolve(__dirname, "wdio-webserver.conf.js"), targetWdioConf)
         const optionsWdioConf = {
             files: targetWdioConf,
-            from: [/url: ''/, /specs: \[.*\]/],
+            from: [/url: "#"/, /specs: \[.*\]/],
             to: [
                 `url: "index-${version}"`, // this is only b/c of the "soerver" webserver in use...
-                `specs: ["examples/ui5-js-app/webapp/test/e2e/basic.test.js"]`
+                `specs: ["${path.resolve(__dirname, "webapp/test/e2e/properties-matcher.test.js")}"]`
             ]
         }
         await replace(optionsWdioConf)

--- a/examples/ui5-js-app/wdi5-multiversion.js
+++ b/examples/ui5-js-app/wdi5-multiversion.js
@@ -6,7 +6,7 @@ const Launcher = require("@wdio/cli").default
 // lts version - with 1.71.19 being the exception
 // in that there seems to be stuff boken in ui5 > 1.71.19 <= 1.71.25
 // empty string will get the newest Version which can be a "SNAPSHOT" version
-const versions = ["", "1.58.4", "1.71.19", "1.84.3"]
+const versions = ["", "1.71.19", "1.84.3"]
 
 ;(async () => {
     for (const version of versions) {

--- a/examples/ui5-js-app/wdi5-multiversion.js
+++ b/examples/ui5-js-app/wdi5-multiversion.js
@@ -5,7 +5,8 @@ const Launcher = require("@wdio/cli").default
 
 // lts version - with 1.71.19 being the exception
 // in that there seems to be stuff boken in ui5 > 1.71.19 <= 1.71.25
-const versions = ["1.100.0-SNAPSHOT", "1.58.4", "1.71.19", "1.84.3", "1.100.0-SNAPSHOT"]
+// empty string will get the newest Version which can be a "SNAPSHOT" version
+const versions = ["", "1.58.4", "1.71.19", "1.84.3"]
 
 ;(async () => {
     for (const version of versions) {

--- a/examples/ui5-js-app/wdi5-multiversion.js
+++ b/examples/ui5-js-app/wdi5-multiversion.js
@@ -5,13 +5,13 @@ const Launcher = require("@wdio/cli").default
 
 // lts version - with 1.71.19 being the exception
 // in that there seems to be stuff boken in ui5 > 1.71.19 <= 1.71.25
-const versions = ["1.58.4", "1.71.19", "1.84.3"]
+const versions = ["1.100.0-SNAPSHOT", "1.58.4", "1.71.19", "1.84.3", "1.100.0-SNAPSHOT"]
 
 ;(async () => {
     for (const version of versions) {
         // create an index.html for bootstrapping per version
         const targetIndex = path.resolve(__dirname, `webapp/index-${version}.html`)
-        const bootstrapSrc = `https://openui5.hana.ondemand.com/${version}/resources/sap-ui-core.js`
+        const bootstrapSrc = `https://openui5nightly.hana.ondemand.com/${version}/resources/sap-ui-core.js`
         fsExtra.copySync(path.resolve(__dirname, `webapp/index.html`), targetIndex)
         const optionsIndex = {
             files: targetIndex,

--- a/examples/ui5-js-app/wdio-webserver.conf.js
+++ b/examples/ui5-js-app/wdio-webserver.conf.js
@@ -20,7 +20,7 @@ exports.config = {
             browserName: "chrome",
             acceptInsecureCerts: true,
             "goog:chromeOptions": {
-                args: process.env.HEADLESS ? ["--headless"] : ["window-size=1440,800"]
+                args: process.env.HEADLESS ? ["--headless"] : ["window-size=1440,800"] // "--auto-open-devtools-for-tabs"
             }
         }
     ],

--- a/examples/ui5-js-app/webapp/test/e2e/generated-methods.test.js
+++ b/examples/ui5-js-app/webapp/test/e2e/generated-methods.test.js
@@ -38,18 +38,6 @@ describe("check the generated methods on the control -> ", () => {
     }
 
     before(async () => {
-        if ((await browser.getUI5VersionAsFloat()) <= 1.6) {
-            buttonSelector.forceSelect = true
-            buttonSelector.selector.interaction = "root"
-            inputSelector.forceSelect = true
-            inputSelector.selector.interaction = "root"
-            dateTimeSelector.forceSelect = true
-            dateTimeSelector.selector.interaction = "root"
-            listSelector.forceSelect = true
-            checkboxSelector.forceSelect = true
-            checkboxSelector.selector.interaction = "root"
-        }
-
         await Main.open()
     })
 

--- a/examples/ui5-js-app/webapp/test/e2e/hash-nav.test.js
+++ b/examples/ui5-js-app/webapp/test/e2e/hash-nav.test.js
@@ -15,11 +15,6 @@ describe("hash-based nav", () => {
         }
         await wdi5.goTo("", oRouteOptions)
 
-        if ((await browser.getUI5VersionAsFloat()) <= 1.6) {
-            listSelector.forceSelect = true
-            listSelector.selector.interaction = "root"
-        }
-
         const items = await browser.asControl(listSelector).getItems(true)
         expect(items.length).toEqual(9)
     })
@@ -32,10 +27,6 @@ describe("hash-based nav", () => {
                 id: "NavFwdButton",
                 viewName: "test.Sample.view.Main"
             }
-        }
-
-        if ((await browser.getUI5VersionAsFloat()) <= 1.6) {
-            buttonSelector.forceSelect = true
         }
 
         expect(await (await browser.asControl(buttonSelector)).getProperty("visible")).toBeTruthy()
@@ -54,11 +45,6 @@ describe("hash-based nav", () => {
             sName: "RouteOther"
         }
         await browser.goTo({ oRoute: oRouteOptions })
-
-        if ((await browser.getUI5VersionAsFloat()) <= 1.6) {
-            listSelector.forceSelect = true
-            listSelector.selector.interaction = "root"
-        }
 
         const list = await browser.asControl(listSelector)
         expect(await list.getVisible()).toBeTruthy()

--- a/examples/ui5-js-app/webapp/test/e2e/interaction.test.js
+++ b/examples/ui5-js-app/webapp/test/e2e/interaction.test.js
@@ -44,10 +44,6 @@ describe("interaction + binding", () => {
             }
         }
 
-        if ((await browser.getUI5VersionAsFloat()) <= 1.6) {
-            buttonSelector.forceSelect = true
-        }
-
         const ui5Button = await browser.asControl(buttonSelector)
         await ui5Button.firePress()
 
@@ -63,10 +59,6 @@ describe("interaction + binding", () => {
                 viewName: viewName,
                 controlType: "sap.m.Input"
             }
-        }
-
-        if ((await browser.getUI5VersionAsFloat()) <= 1.6) {
-            inputSelector.forceSelect = true
         }
 
         const ui5Input = await browser.asControl(inputSelector)

--- a/examples/ui5-js-app/webapp/test/e2e/list-interaction.test.js
+++ b/examples/ui5-js-app/webapp/test/e2e/list-interaction.test.js
@@ -18,13 +18,6 @@ describe("list interaction", () => {
 
     before(async () => {
         await Other.open()
-
-        if ((await browser.getUI5VersionAsFloat()) <= 1.6) {
-            buttonSelector.forceSelect = true
-            buttonSelector.selector.interaction = "root"
-            listSelector.forceSelect = true
-            listSelector.selector.interaction = "root"
-        }
     })
 
     beforeEach(async () => {
@@ -62,10 +55,6 @@ describe("list interaction", () => {
                 id: "idTextFieldClickResult",
                 viewName: "test.Sample.view.Other"
             }
-        }
-        if ((await browser.getUI5VersionAsFloat()) <= 1.6) {
-            textFieldSelector.forceSelect = true
-            textFieldSelector.selector.interaction = "root"
         }
 
         const mockedListItemPress = await browser.asControl(textFieldSelector)

--- a/examples/ui5-js-app/webapp/test/e2e/locators-basic.test.js
+++ b/examples/ui5-js-app/webapp/test/e2e/locators-basic.test.js
@@ -49,11 +49,6 @@ describe("mixed locators", () => {
             }
         }
 
-        if ((await browser.getUI5VersionAsFloat()) <= 1.6) {
-            selector.forceSelect = true
-            selector.selector.interaction = "root"
-        }
-
         const control = await browser.asControl(selector)
         const retrievedClassNameStatus = await control.hasStyleClass(className)
 

--- a/examples/ui5-js-app/webapp/test/e2e/locators-regex.test.js
+++ b/examples/ui5-js-app/webapp/test/e2e/locators-regex.test.js
@@ -61,11 +61,6 @@ describe("RegEx locators", () => {
                 }
             }
 
-            if ((await browser.getUI5VersionAsFloat()) <= 1.6) {
-                openButtonSelector.forceSelect = true
-                openButtonSelector.selector.interaction = "root"
-            }
-
             await browser.asControl(openButtonSelector).press()
 
             const popup = await browser.asControl(dialogSelector)

--- a/examples/ui5-js-app/webapp/test/e2e/pageObjects/Main.js
+++ b/examples/ui5-js-app/webapp/test/e2e/pageObjects/Main.js
@@ -17,11 +17,6 @@ class Main extends Page {
             }
         }
 
-        if ((await browser.getUI5VersionAsFloat()) <= 1.6) {
-            cbSelector1.forceSelect = true
-            cbSelector1.selector.interaction = "root"
-        }
-
         return await browser.asControl(cbSelector1)
     }
 }

--- a/examples/ui5-js-app/webapp/test/e2e/pageObjects/Other.js
+++ b/examples/ui5-js-app/webapp/test/e2e/pageObjects/Other.js
@@ -28,11 +28,6 @@ class Other extends Page {
             forceSelect: force //> this will populate down to $ui5Control.getAggregation and $ui5Control.getProperty as well
         }
 
-        if ((await browser.getUI5VersionAsFloat()) <= 1.6) {
-            listSelector.forceSelect = true
-            listSelector.selector.interaction = "root"
-        }
-
         return await browser.asControl(listSelector)
     }
 

--- a/examples/ui5-js-app/webapp/test/e2e/press.test.js
+++ b/examples/ui5-js-app/webapp/test/e2e/press.test.js
@@ -20,10 +20,6 @@ describe("custom wdi5 press event", async () => {
 
     before(async () => {
         await Main.open()
-        if ((await browser.getUI5VersionAsFloat()) <= 1.6) {
-            openButtonSelector.forceSelect = true
-            openButtonSelector.selector.interaction = "root"
-        }
     })
 
     afterEach(async () => {

--- a/examples/ui5-js-app/webapp/test/e2e/properties-matcher.test.js
+++ b/examples/ui5-js-app/webapp/test/e2e/properties-matcher.test.js
@@ -1,0 +1,82 @@
+// helper class "wdi5" contained in wdio service "ui5"
+const { wdi5 } = require("wdio-ui5-service")
+
+describe("Property locators", () => {
+    const mainViewName = "test.Sample.view.Main"
+    const otherViewName = "test.Sample.view.Other"
+
+    // before(async () => {
+    //     await Main.open()
+    // })
+
+    it("should find the 'open dialog' button by the text property", async () => {
+        const selectorByPropertyText = {
+            selector: {
+                controlType: "sap.m.Button",
+                viewName: mainViewName,
+                properties: {
+                    text: "open Dialog"
+                }
+            }
+        }
+        const textFromButton = await browser.asControl(selectorByPropertyText).getText()
+        expect(textFromButton).toEqual("open Dialog")
+    })
+
+    it("should find the 'to Other view' button by the icon property and click on it", async () => {
+        const selectorWithIconProperty = {
+            selector: {
+                controlType: "sap.m.Button",
+                viewName: mainViewName,
+                properties: {
+                    icon: "sap-icon://forward"
+                }
+            }
+        }
+        const toOtherViewButton = await browser.asControl(selectorWithIconProperty)
+        const textFromButton = await toOtherViewButton.getText()
+        expect(textFromButton).toEqual("to Other view")
+        await toOtherViewButton.press()
+    })
+
+    it("should find the List by the header Text", async () => {
+        const selectorWithHeaderTextProperty = {
+            selector: {
+                controlType: "sap.m.List",
+                viewName: otherViewName,
+                properties: {
+                    headerText: "...bites the dust!"
+                }
+            }
+        }
+        const headerTextFromList = await browser.asControl(selectorWithHeaderTextProperty).getHeaderText()
+        expect(headerTextFromList).toEqual("...bites the dust!")
+    })
+    it("should find the third entry in the List", async () => {
+        const selectorWithTitleProperty = {
+            selector: {
+                controlType: "sap.m.StandardListItem",
+                viewName: otherViewName,
+                properties: {
+                    title: "Margaret Peacock"
+                }
+            }
+        }
+        const titleFromListItem = await browser.asControl(selectorWithTitleProperty).getTitle()
+        expect(titleFromListItem).toEqual("Margaret Peacock")
+        await browser.asControl(selectorWithTitleProperty).press()
+
+        const selector = {
+            selector: {
+                controlType: "sap.m.Text",
+                viewName: otherViewName,
+                properties: {
+                    text: "Margaret Peacock",
+                    visible: true
+                }
+            }
+        }
+        const selectorText = await browser.asControl(selector).getText()
+        expect(selectorText).toEqual("Margaret Peacock")
+    })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,9 @@
         "examples/ui5-js-app",
         "examples/ui5-ts-app"
       ],
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
       "devDependencies": {
         "@commitlint/cli": "^16.2.1",
         "@commitlint/config-conventional": "^16.2.1",
@@ -10615,7 +10618,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -12547,7 +12549,6 @@
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
       "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -14001,8 +14002,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
       "version": "1.10.2",
@@ -23526,7 +23526,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -24959,7 +24958,6 @@
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
       "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -25970,6 +25968,7 @@
         "prettier": "^2.5.1",
         "replace-in-file": "^6.3.2",
         "rimraf": "^3.0.2",
+        "semver": "*",
         "soerver": "^0.0.3",
         "standard-version": "^9.3.2",
         "terser": "^5.11.0",
@@ -35253,7 +35252,6 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -36686,7 +36684,6 @@
           "version": "7.3.5",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
           "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -37830,8 +37827,7 @@
         "yallist": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
         "yaml": {
           "version": "1.10.2",
@@ -38188,8 +38184,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
       "version": "1.10.2",

--- a/package.json
+++ b/package.json
@@ -80,5 +80,8 @@
   "engines": {
     "node": ">=14",
     "npm": ">=7"
+  },
+  "dependencies": {
+    "semver": "^7.3.5"
   }
 }

--- a/src/lib/wdi5-bridge.ts
+++ b/src/lib/wdi5-bridge.ts
@@ -229,15 +229,6 @@ export async function addWdi5Commands() {
         return _sapUI5Version
     })
 
-    browser.addCommand("getUI5VersionAsFloat", async () => {
-        // TODO: what happens when we reach version 1.100? parseFloat will return 1.1
-        if (!_sapUI5Version) {
-            // implicit setter for _sapUI5Version
-            await browser.getUI5Version()
-        }
-        return parseFloat(_sapUI5Version)
-    })
-
     /**
      * uses the UI5 native waitForUI5 function to wait for all promises to be settled
      */

--- a/src/lib/wdi5-bridge.ts
+++ b/src/lib/wdi5-bridge.ts
@@ -99,6 +99,12 @@ export async function start(config: wdi5Config) {
  * attach the sap/ui/test/RecordReplay object to the application context window object as 'bridge'
  */
 export async function injectUI5(config: wdi5Config) {
+    const ui5Version = await browser.getUI5VersionAsFloat()
+    if (ui5Version < 1.6) {
+        // the record replay api is only available since 1.60
+        Logger.error("The ui5 version of your application is to low. Minimum required UI5 version is 1.60")
+        throw new Error("The ui5 version of your application is to low. Minimum required UI5 version is 1.60")
+    }
     const waitForUI5Timeout = config.wdi5.waitForUI5Timeout || 15000
     // expect boolean
     const result = await clientSide_injectUI5(config, waitForUI5Timeout)

--- a/src/lib/wdi5-bridge.ts
+++ b/src/lib/wdi5-bridge.ts
@@ -1,6 +1,7 @@
 import { resolve } from "path"
 import { writeFile } from "fs/promises"
 import { tmpdir } from "os"
+import * as semver from "semver"
 
 import { wdi5Config, wdi5Selector } from "../types/wdi5.types"
 import { WDI5Control } from "./wdi5-control"
@@ -99,8 +100,8 @@ export async function start(config: wdi5Config) {
  * attach the sap/ui/test/RecordReplay object to the application context window object as 'bridge'
  */
 export async function injectUI5(config: wdi5Config) {
-    const ui5Version = await browser.getUI5VersionAsFloat()
-    if (ui5Version < 1.6) {
+    const ui5Version = await browser.getUI5Version()
+    if (semver.lt(ui5Version, "1.60.0")) {
         // the record replay api is only available since 1.60
         Logger.error("The ui5 version of your application is to low. Minimum required UI5 version is 1.60")
         throw new Error("The ui5 version of your application is to low. Minimum required UI5 version is 1.60")
@@ -197,11 +198,11 @@ export async function addWdi5Commands() {
     })
 
     browser.addCommand("getUI5VersionAsFloat", async () => {
+        // TODO: what happens when we reach version 1.100? parseFloat will return 1.1
         if (!_sapUI5Version) {
             // implicit setter for _sapUI5Version
             await browser.getUI5Version()
         }
-
         return parseFloat(_sapUI5Version)
     })
 

--- a/src/types/browser-commands.ts
+++ b/src/types/browser-commands.ts
@@ -22,7 +22,6 @@ declare global {
             _controls: cachedControl[]
 
             getUI5Version: () => Promise<string>
-            getUI5VersionAsFloat: () => Promise<number>
         }
 
         // interface MultiRemoteBrowser {


### PR DESCRIPTION
- wdi5 now determines the versions correctly and throws an wdi5 and wdio error if the ui5 version is below 1.60
- removed the `getUI5VersionAsFloat` function and it's usage, as it will not return the correct version in some cases.
- Instantiate the matchers correctly when the ui5 version is below 1.72
- added a dedicated properties-matcher script
- fixed some minor bugs in the multiversion script

Next step would be to integrate the multiversion script in the pipeline as well