### PR TITLE
Fix: Version Checks

### DIFF
--- a/client-side-js/_navTo.js
+++ b/client-side-js/_navTo.js
@@ -5,20 +5,27 @@ async function clientSide__navTo(sComponentId, sName, oParameters, oComponentTar
                 window.wdi5.Log.info(`[browser wdi5] navigation to ${sName} triggered`)
 
                 const router = sap.ui.getCore().getComponent(sComponentId).getRouter()
-                const hashChanger =
-                    parseFloat(sap.ui.version) < 1.75
-                        ? sap.ui.core.routing.HashChanger.getInstance()
-                        : router.getHashChanger()
+                debugger
+                const hashChanger = window.compareVersions.compare("1.75.0", sap.ui.version, ">")
+                    ? sap.ui.core.routing.HashChanger.getInstance()
+                    : router.getHashChanger()
 
                 // on success result is the router
                 hashChanger.attachEvent("hashChanged", (oEvent) => {
-                    done(["success", parseFloat(sap.ui.version) < 1.75 ? hashChanger.getHash() : hashChanger.hash])
+                    done([
+                        "success",
+                        window.compareVersions.compare("1.75.0", sap.ui.version, ">")
+                            ? hashChanger.getHash()
+                            : hashChanger.hash
+                    ])
                 })
 
                 // get component and trigger router
                 // sName, oParameters?, oComponentTargetInfo?, bReplace?
                 router.navTo(sName, oParameters, oComponentTargetInfo, bReplace)
-                return parseFloat(sap.ui.version) < 1.75 ? hashChanger.getHash() : hashChanger.hash
+                return window.compareVersions.compare("1.75.0", sap.ui.version, ">")
+                    ? hashChanger.getHash()
+                    : hashChanger.hash
             })
         },
         sComponentId,

--- a/client-side-js/_navTo.js
+++ b/client-side-js/_navTo.js
@@ -5,7 +5,6 @@ async function clientSide__navTo(sComponentId, sName, oParameters, oComponentTar
                 window.wdi5.Log.info(`[browser wdi5] navigation to ${sName} triggered`)
 
                 const router = sap.ui.getCore().getComponent(sComponentId).getRouter()
-                debugger
                 const hashChanger = window.compareVersions.compare("1.75.0", sap.ui.version, ">")
                     ? sap.ui.core.routing.HashChanger.getInstance()
                     : router.getHashChanger()

--- a/client-side-js/injectUI5.js
+++ b/client-side-js/injectUI5.js
@@ -102,7 +102,11 @@ async function clientSide_injectUI5(config, waitForUI5Timeout) {
                             const isRootProperty =
                                 oSelector.bindingPath.propertyPath &&
                                 oSelector.bindingPath.propertyPath.charAt(0) === "/"
-                            if (hasNamedModel && isRootProperty && parseFloat(sap.ui.version) < 1.81) {
+                            if (
+                                hasNamedModel &&
+                                isRootProperty &&
+                                window.compareVersions.compare("1.81.0", sap.ui.version, ">")
+                            ) {
                                 // attach the double leading /
                                 // for UI5 < 1.81
                                 oSelector.bindingPath.propertyPath = `/${oSelector.bindingPath.propertyPath}`

--- a/client-side-js/interactWithControl.js
+++ b/client-side-js/interactWithControl.js
@@ -5,16 +5,7 @@ async function clientSide_interactWithControl(oOptions) {
             .then(() => {
                 window.wdi5.Log.info("[browser wdi5] locating controlSelector")
                 oOptions.selector = window.wdi5.createMatcher(oOptions.selector)
-                if (parseFloat(sap.ui.version) <= 1.6) {
-                    // implementing legacy api < 1.60
-                    window.bridge.findDOMElementByControlSelector(oOptions).then((control, arg) => {
-                        const ui5Control = window.wdi5.getUI5CtlForWebObj(control)
-                        oOptions.control = ui5Control
-                        return window.bridge.interactWithControl(oOptions)
-                    })
-                } else {
-                    return window.bridge.interactWithControl(oOptions)
-                }
+                return window.bridge.interactWithControl(oOptions)
             })
             .then((result) => {
                 window.wdi5.Log.info("[browser wdi5] interaction complete! - Message: " + result)


### PR DESCRIPTION
Remove unnecessary version checks (below version 1.60) and replace the `parseFloat` checks with `semver`