### PR TITLE
docs: fix favicon

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -6,6 +6,7 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
         <meta name="description" content="Description" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0" />
+        <link type="image/x-icon" rel="icon" href="/wdi5/favicon.ico" />
         <!-- Theme: Simple Dark -->
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/css/theme-simple-dark.css" />
     </head>


### PR DESCRIPTION
# Problem
Your docs are under the path `/wdi5/`. 
Since the favicon was not explicitly specified in `index.html`, this path is not used.
Therefor a 404 error pops up.
![image](https://user-images.githubusercontent.com/13335743/165383908-08830b80-7995-4793-a02d-39cf30854359.png)
# Changes
Add explicit definition of the `favicon.ico` with wdi5 path to the index.html.

# Test
Works in my fork:
https://marianfoo.github.io/wdi5/#/