### PR TITLE
feat: change all ENV variables to arguments

### DIFF
--- a/.github/workflows/wdi5-tests.js.yml
+++ b/.github/workflows/wdi5-tests.js.yml
@@ -71,4 +71,4 @@ jobs:
 
       # run wdi5 tests within app(s)
       - name: test js-app
-        run: npm run test:js-app -- -- --headless
+        run: npm run test-h:js-app

--- a/.github/workflows/wdi5-tests.js.yml
+++ b/.github/workflows/wdi5-tests.js.yml
@@ -71,4 +71,4 @@ jobs:
 
       # run wdi5 tests within app(s)
       - name: test js-app
-        run: npm run test:js-app --headless
+        run: npm run test:js-app -- --headless

--- a/.github/workflows/wdi5-tests.js.yml
+++ b/.github/workflows/wdi5-tests.js.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: update chrome
         run: |
-          wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add - 
+          wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
           sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
           sudo apt-get update
           sudo apt-get --only-upgrade install google-chrome-stable
@@ -71,4 +71,4 @@ jobs:
 
       # run wdi5 tests within app(s)
       - name: test js-app
-        run: HEADLESS=true npm run test:js-app
+        run: npm run test:js-app --headless

--- a/.github/workflows/wdi5-tests.js.yml
+++ b/.github/workflows/wdi5-tests.js.yml
@@ -71,4 +71,4 @@ jobs:
 
       # run wdi5 tests within app(s)
       - name: test js-app
-        run: npm run test:js-app -- --headless
+        run: npm run test:js-app -- -- --headless

--- a/examples/ui5-js-app/package.json
+++ b/examples/ui5-js-app/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "serve": "ui5 serve",
     "test": "run-s test:*",
+    "test-h": "run-s \"test:* -- --headless\"",
     "start": "soerver -d ./webapp -p 8888 -x ./webapp/proxyrc.json",
     "test:lateInject": "wdio run wdio-ui5-late.conf.js",
     "test:ui5tooling": "wdio run wdio-ui5tooling.conf.js",

--- a/examples/ui5-js-app/scripts/getBrowsers.js
+++ b/examples/ui5-js-app/scripts/getBrowsers.js
@@ -1,0 +1,25 @@
+/**
+ * analyse browser arguments
+ */
+exports.getBrowsers = function () {
+    const availableBrowsers = ["chrome", "safari", "edge", "firefox"]
+    const argv = process.argv
+    let browsers = []
+    const _browsers = argv.indexOf("--browsers")
+
+    if (_browsers > -1) {
+        // contain browsers
+        // slice all params before
+        const myArgs = process.argv.slice(_browsers + 1)
+
+        browsers = myArgs.filter(function (element) {
+            return availableBrowsers.includes(element)
+        })
+
+        console.log(`BROWSERS: ${browsers}`)
+        return browsers
+    }
+    // browsers not set return all
+    console.log(`BROWSERS: ${availableBrowsers}`)
+    return availableBrowsers
+}

--- a/examples/ui5-js-app/wdio-docker-selenium.conf.js
+++ b/examples/ui5-js-app/wdio-docker-selenium.conf.js
@@ -1,3 +1,5 @@
+const { getBrowsers } = require("./scripts/getBrowsers")
+
 // TODO: use wdio.base.conf.js
 const chrome = {
     maxInstances: 1,
@@ -49,8 +51,7 @@ const _config = {
     }
 }
 
-const browsers = process.env.BROWSERS
-console.log(`browsers: ${browsers}`)
+const browsers = getBrowsers()
 
 if (browsers) {
     if (browsers.includes("chrome")) {

--- a/examples/ui5-js-app/wdio-docker.conf.js
+++ b/examples/ui5-js-app/wdio-docker.conf.js
@@ -1,3 +1,5 @@
+const { getBrowsers } = require("./scripts/getBrowsers")
+
 // TODO: use wdio.base.conf.js
 const chrome = {
     maxInstances: 1,
@@ -75,8 +77,7 @@ const _config = {
     }
 }
 
-const browsers = process.env.BROWSERS
-console.log(`browsers: ${browsers}`)
+const browsers = getBrowsers()
 
 if (browsers) {
     if (browsers.includes("chrome")) {

--- a/examples/ui5-js-app/wdio.base.conf.js
+++ b/examples/ui5-js-app/wdio.base.conf.js
@@ -12,11 +12,12 @@ exports.baseConfig = {
             browserName: "chrome",
             acceptInsecureCerts: true,
             "goog:chromeOptions": {
-                args: process.env.HEADLESS
-                    ? ["window-size=1440,800", "--headless"]
-                    : process.env.DEBUG
-                    ? ["window-size=1920,1280", "--auto-open-devtools-for-tabs"]
-                    : ["window-size=1440,800"]
+                args:
+                    process.argv.indexOf("--headless") > -1
+                        ? ["window-size=1440,800", "--headless"]
+                        : process.argv.indexOf("--debug") > -1
+                        ? ["window-size=1920,1280", "--auto-open-devtools-for-tabs"]
+                        : ["window-size=1440,800"]
             }
         }
     ],

--- a/examples/ui5-ts-app/wdio-ui5.conf.ts
+++ b/examples/ui5-ts-app/wdio-ui5.conf.ts
@@ -59,11 +59,12 @@ export const config: wdi5Config = {
             //
             browserName: "chrome",
             "goog:chromeOptions": {
-                args: process.env.HEADLESS
-                    ? ["--headless"]
-                    : process.env.DEBUG
-                    ? ["window-size=1440,800", "--auto-open-devtools-for-tabs"]
-                    : ["window-size=1440,800"]
+                args:
+                    process.argv.indexOf("--headless") > -1
+                        ? ["--headless"]
+                        : process.argv.indexOf("--debug") > -1
+                        ? ["window-size=1440,800", "--auto-open-devtools-for-tabs"]
+                        : ["window-size=1440,800"]
             },
             acceptInsecureCerts: true
             // If outputDir is provided WebdriverIO can capture driver session logs

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "_startApp:js-tooling": "npm run serve --workspace=examples/ui5-js-app",
     "_startApp:ts": "tbd",
     "_test:js-app": "wait-on tcp:8888 && wait-on tcp:8080 && npm run test --workspace=examples/ui5-js-app",
+    "_test:js-app-h": "wait-on tcp:8888 && wait-on tcp:8080 && npm run test-h --workspace=examples/ui5-js-app",
+    "test-h:js-app": "run-p -r _startApp:js _startApp:js-tooling _test-h:js-app",
     "test:js-app": "run-p -r _startApp:js _startApp:js-tooling _test:js-app",
     "test": "cross-env TS_NODE_PROJECT=\"test/tsconfig.json\" mocha",
     "prepare": "husky install",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "_startApp:js-tooling": "npm run serve --workspace=examples/ui5-js-app",
     "_startApp:ts": "tbd",
     "_test:js-app": "wait-on tcp:8888 && wait-on tcp:8080 && npm run test --workspace=examples/ui5-js-app",
-    "_test:js-app-h": "wait-on tcp:8888 && wait-on tcp:8080 && npm run test-h --workspace=examples/ui5-js-app",
+    "_test-h:js-app": "wait-on tcp:8888 && wait-on tcp:8080 && npm run test-h --workspace=examples/ui5-js-app",
     "test-h:js-app": "run-p -r _startApp:js _startApp:js-tooling _test-h:js-app",
     "test:js-app": "run-p -r _startApp:js _startApp:js-tooling _test:js-app",
     "test": "cross-env TS_NODE_PROJECT=\"test/tsconfig.json\" mocha",


### PR DESCRIPTION
start test with eg.
```
npm run test:webserver -w examples/ui5-js-app -- --spec /basic.test.js --browsers firefox chrome
```
and/ or
```
npm run test:webserver -w examples/ui5-js-app -- --spec /basic.test.js --headless --debug
```