### PR TITLE
fix: avoid referenced object manipulation (#275)

### DIFF
--- a/client-side-js/executeControlMethod.js
+++ b/client-side-js/executeControlMethod.js
@@ -55,14 +55,15 @@ async function clientSide_executeControlMethod(webElement, methodName, args) {
                             ) {
                                 // object, replacer function
                                 // create usefull content from result
-                                while (window.wdi5.isCyclic(result)) {
-                                    result = JSON.parse(
-                                        JSON.stringify(
-                                            window.wdi5.removeCyclic(result),
-                                            window.wdi5.getCircularReplacer()
-                                        )
-                                    )
-                                }
+                                result = window.wdi5.collapseObject(result)
+                                // while (window.wdi5.isCyclic(result)) {
+                                //     result = JSON.parse(
+                                //         JSON.stringify(
+                                //             window.wdi5.removeCyclic(result),
+                                //             window.wdi5.getCircularReplacer()
+                                //         )
+                                //     )
+                                // }
                                 done({
                                     status: 0,
                                     result: result,

--- a/client-side-js/executeControlMethod.js
+++ b/client-side-js/executeControlMethod.js
@@ -53,22 +53,17 @@ async function clientSide_executeControlMethod(webElement, methodName, args) {
                                 // allows method chaining
                                 !(result instanceof sap.ui.core.Control)
                             ) {
-                                // object, replacer function
-                                // create usefull content from result
-                                result = window.wdi5.collapseObject(result)
-                                // while (window.wdi5.isCyclic(result)) {
-                                //     result = JSON.parse(
-                                //         JSON.stringify(
-                                //             window.wdi5.removeCyclic(result),
-                                //             window.wdi5.getCircularReplacer()
-                                //         )
-                                //     )
-                                // }
+                                // flatten the prototype so we have all funcs available
+                                const collapsed = window.wdi5.collapseObject(result)
+                                // exclude cyclic references
+                                const collapsedAndNonCyclic = JSON.parse(
+                                    JSON.stringify(collapsed, window.wdi5.getCircularReplacer())
+                                )
                                 done({
                                     status: 0,
-                                    result: result,
+                                    result: collapsedAndNonCyclic,
                                     returnType: "result",
-                                    nonCircularResultObject: result
+                                    nonCircularResultObject: collapsedAndNonCyclic
                                 })
                             } else {
                                 // check if of control to verify if the method result is a different control

--- a/client-side-js/injectUI5.js
+++ b/client-side-js/injectUI5.js
@@ -247,28 +247,11 @@ async function clientSide_injectUI5(config, waitForUI5Timeout) {
                         return controlMethodsToProxy
                     }
 
-                    window.wdi5.isCyclic = (obj) => {
-                        var seenObjects = []
-
-                        function detect(obj) {
-                            if (obj && typeof obj === "object") {
-                                if (seenObjects.indexOf(obj) !== -1) {
-                                    return true
-                                }
-                                seenObjects.push(obj)
-                                for (var key in obj) {
-                                    if (obj.hasOwnProperty(key) && detect(obj[key])) {
-                                        console.log(obj, "cycle at " + key)
-                                        return true
-                                    }
-                                }
-                            }
-                            return false
-                        }
-
-                        return detect(obj)
-                    }
-
+                    /**
+                     * flatten all functions and properties on the Prototype directly into the returned object
+                     * @param {object} obj
+                     * @returns {object} all functions and properties of the inheritance chain in a flat structure
+                     */
                     window.wdi5.collapseObject = (obj) => {
                         let protoChain = []
                         let proto = obj
@@ -281,36 +264,10 @@ async function clientSide_injectUI5(config, waitForUI5Timeout) {
                         return collapsedObj
                     }
 
-                    window.wdi5.removeCyclic = (obj) => {
-                        var seenObjects = []
-
-                        function detect(obj) {
-                            if (obj && typeof obj === "object") {
-                                if (seenObjects.indexOf(obj) !== -1) {
-                                    return obj
-                                }
-                                seenObjects.push(obj)
-                                for (var key in obj) {
-                                    if (obj.hasOwnProperty(key) && detect(obj[key])) {
-                                        console.log(obj, "cycle at " + key)
-                                        console.warn(`deleted: ${key}`)
-                                        delete obj[key]
-                                        return obj
-                                    }
-                                }
-                            } else {
-                                console.log(`removed ${typeof obj}`)
-                            }
-                            return obj
-                        }
-
-                        return detect(obj)
-                    }
-
                     /**
                      * used as a replacer function in JSON.stringify
                      * removes circular references in an object
-                     * @returns
+                     * all credit to https://bobbyhadz.com/blog/javascript-typeerror-converting-circular-structure-to-json
                      */
                     window.wdi5.getCircularReplacer = () => {
                         const seen = new WeakSet()

--- a/client-side-js/injectUI5.js
+++ b/client-side-js/injectUI5.js
@@ -269,6 +269,18 @@ async function clientSide_injectUI5(config, waitForUI5Timeout) {
                         return detect(obj)
                     }
 
+                    window.wdi5.collapseObject = (obj) => {
+                        let protoChain = []
+                        let proto = obj
+                        while (proto !== null) {
+                            protoChain.unshift(proto)
+                            proto = Object.getPrototypeOf(proto)
+                        }
+                        let collapsedObj = {}
+                        protoChain.forEach((prop) => Object.assign(collapsedObj, prop))
+                        return collapsedObj
+                    }
+
                     window.wdi5.removeCyclic = (obj) => {
                         var seenObjects = []
 


### PR DESCRIPTION
- introduce collapseObject for flattening the inheritance Prototype
  this avoids deletion of original object's properties,
  causing unintended side effects
- rm unused window.wdi5...
  - isCyclic
  - removeCyclic
- should fix #275