### PR TITLE
chore: change gitmodule to url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "examples/cap-bookshop-wdi5"]
 	path = examples/cap-bookshop-wdi5
-	url = git@github.com:SAP-samples/cap-bookshop-wdi5.git
+	url = https://github.com/SAP-samples/cap-bookshop-wdi5.git
 	branch = wdi5-tests


### PR DESCRIPTION
i have a problem when i clone wdi5 becaues of the definition in gitmodules.
Can this be changed to the url?