### PR TITLE
fix(wdi5): handle browser context loss during FE initialization

### DIFF
--- a/src/client-side-js/injectUI5.ts
+++ b/src/client-side-js/injectUI5.ts
@@ -121,7 +121,8 @@ async function clientSide_injectUI5(waitForUI5Timeout: number, browserInstance: 
 
             // attach new bridge
             window.bridge = RecordReplayUi5LocalRef
-            window.fe_bridge = {} // empty init for fiori elements test api
+            // Use conditional assignment to avoid overwriting existing fe_bridge (e.g., if re-injecting)
+            window.fe_bridge = window.fe_bridge || {}
             window.wdi5.Log.info("[browser wdi5] APIs injected!")
             window.wdi5.isInitialized = true
 

--- a/src/client-side-js/testLibrary.ts
+++ b/src/client-side-js/testLibrary.ts
@@ -150,6 +150,8 @@ async function loadFELibraries(browserInstance: WebdriverIO.Browser) {
                 )
             }
         )
+        // Ensure fe_bridge exists (defensive check in case browser context was lost)
+        window.fe_bridge = window.fe_bridge || {}
         window.fe_bridge.ListReport = ListReport
         window.fe_bridge.ObjectPage = ObjectPage
         window.fe_bridge.Shell = Shell


### PR DESCRIPTION
Detect and recover from lost wdi5 bridge (e.g., after redirects) by re-injecting before loading FE libraries. Use defensive assignment for fe_bridge to prevent overwrites.